### PR TITLE
Use https URL for rust-installer-v2.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/rust-lang/rust-installer
 [submodule "test/rust-installer-v2"]
 	path = test/rust-installer-v2
-	url = http://github.com/rust-lang/rust-installer
+	url = https://github.com/rust-lang/rust-installer


### PR DESCRIPTION
GitHub URLs should use HTTPS, not HTTP. This is currently blocking BitRust (https://github.com/mrmonday/bitrust, http://bitrust.octarineparrot.com/), since GitHub pages require HTTPS for sub-modules.