### PR TITLE
add support for OpenBSD system.

### DIFF
--- a/install-template.sh
+++ b/install-template.sh
@@ -757,7 +757,7 @@ need_cmd tr
 need_cmd sed
 need_cmd chmod
 
-CFG_ARGS="$@"
+CFG_ARGS="${@:-}"
 
 HELP=0
 if [ "${1-}" = "--help" ]
@@ -835,7 +835,7 @@ src_basename="$(basename "$0")"
 # then we're doing a full uninstall, as opposed to the --uninstall flag
 # which just means 'uninstall my components'.
 if [ "$src_basename" = "uninstall.sh" ]; then
-    if [ "$*" != "" ]; then
+    if [ "${*:-}" != "" ]; then
 	# Currently don't know what to do with arguments in this mode
 	err "uninstall.sh does not take any arguments"
     fi

--- a/install-template.sh
+++ b/install-template.sh
@@ -327,6 +327,10 @@ get_host_triple() {
             _ostype=unknown-dragonfly
             ;;
 
+        OpenBSD)
+            _ostype=unknown-openbsd
+	    ;;
+
 	Darwin)
             _ostype=apple-darwin
             ;;


### PR DESCRIPTION
This add support for OpenBSD.

But I still have an issue with `/bin/sh` under OpenBSD, with `set -u` (in `install-template.sh`): when a script is called without arguments, the variable `$@` isn't setted, and `test.sh` failed:

```
$ sh ./test.sh
[...]
test: uninstall_from_installed_script
$ sh /home/builder/build/rust-installer/tmp/prefix/lib/packagelib/uninstall.sh
/home/builder/build/rust-installer/tmp/prefix/lib/packagelib/uninstall.sh[760]: @: parameter not set
```