### PR TITLE
Suppress cd output when determining src_dir

### DIFF
--- a/gen-installer.sh
+++ b/gen-installer.sh
@@ -256,7 +256,9 @@ fi
 step_msg "validating arguments"
 validate_opt
 
-src_dir="$(cd $(dirname "$0") && pwd)"
+# Redirect output of cd command, as it can display the new path when
+# CDPATH is set in bash (which is used for /bin/sh, at least on OS X).
+src_dir="$(cd $(dirname "$0") > /dev/null && pwd)"
 
 rust_installer_version=`cat "$src_dir/rust-installer-version"`
 


### PR DESCRIPTION
On OS X, cd can output the new directory to stdout on success.  This commit
just redirects the output of cd to /dev/null.

This fixes a problem installing multirust on OS X.