### PR TITLE
install-template.sh: fix a refactoring slip-up in valopt (#22)

### DIFF
--- a/install-template.sh
+++ b/install-template.sh
@@ -186,7 +186,7 @@ valopt() {
         then
             default="<none>"
         fi
-        op="${default}=[${default}]"
+        op="${op}=[${default}]"
         printf "    --%-30s %s\n" "$op" "$doc"
     fi
 }


### PR DESCRIPTION
This should fix the `--<none>=[<none>]` behavior mentioned in issue #22.

I noticed it after trying a nightly tarball for the first time today. I made and tested the same change using rust's install.sh, then ported it here. In other words, I haven't directly tested this change, so maybe double-check that it works before merging ;)