### PR TITLE
use invoking shell to execute other shell scripts

### DIFF
--- a/combine-installers.sh
+++ b/combine-installers.sh
@@ -316,7 +316,11 @@ if [ -n "$CFG_NON_INSTALLED_OVERLAY" ]; then
 fi
 
 # Generate the install script
-"$src_dir/gen-install-script.sh" \
+if [ -z "$SHELL" ]; then
+	SHELL=/bin/sh
+fi
+
+"$SHELL" "$src_dir/gen-install-script.sh" \
     --product-name="$CFG_PRODUCT_NAME" \
     --rel-manifest-dir="$CFG_REL_MANIFEST_DIR" \
     --success-message="$CFG_SUCCESS_MESSAGE" \

--- a/gen-installer.sh
+++ b/gen-installer.sh
@@ -327,7 +327,11 @@ if [ -n "$CFG_NON_INSTALLED_OVERLAY" ]; then
 fi
 
 # Generate the install script
-"$src_dir/gen-install-script.sh" \
+if [ -z "$SHELL" ]; then
+	SHELL=/bin/sh
+fi
+
+"$SHELL" "$src_dir/gen-install-script.sh" \
     --product-name="$CFG_PRODUCT_NAME" \
     --rel-manifest-dir="$CFG_REL_MANIFEST_DIR" \
     --success-message="$CFG_SUCCESS_MESSAGE" \


### PR DESCRIPTION
Use the same shell that was used to invoke the script to execute other
shell scripts.

This combined with pull request #81 completely fixes #25845