### PR TITLE
Add generation of XZ-compressed tarballs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,7 @@
+addons:
+  apt:
+    packages:
+    - p7zip-full
+
 script:
   - ./test.sh

--- a/gen-installer.sh
+++ b/gen-installer.sh
@@ -210,7 +210,6 @@ abs_path() {
 msg "looking for programs"
 msg
 
-need_cmd tar
 need_cmd cp
 need_cmd rm
 need_cmd mkdir
@@ -339,9 +338,7 @@ need_ok "failed to generate install script"
 mkdir -p "$CFG_OUTPUT_DIR"
 need_ok "couldn't create output dir"
 
-rm -Rf "$CFG_OUTPUT_DIR/$CFG_PACKAGE_NAME.tar.gz"
-need_ok "couldn't delete old tarball"
-
-# Make a tarball
-tar -czf "$CFG_OUTPUT_DIR/$CFG_PACKAGE_NAME.tar.gz" -C "$CFG_WORK_DIR" "$CFG_PACKAGE_NAME"
-need_ok "failed to tar"
+"$src_dir/make-tarballs.sh" \
+    --work-dir="$CFG_WORK_DIR" \
+    --input="$CFG_PACKAGE_NAME" \
+    --output="$CFG_OUTPUT_DIR/$CFG_PACKAGE_NAME"

--- a/test.sh
+++ b/test.sh
@@ -282,6 +282,7 @@ tarball_with_package_name() {
 	--package-name=rustc-nightly
     try "$WORK_DIR/rustc-nightly/install.sh" --prefix="$PREFIX_DIR"
     try test -e "$OUT_DIR/rustc-nightly.tar.gz"
+    try test -e "$OUT_DIR/rustc-nightly.tar.xz"
 }
 runtest tarball_with_package_name
 


### PR DESCRIPTION
Compress the tarballs with both gzip (for backward compatibility) and
xz (to get better compression).

This is part of the preliminary work for https://github.com/rust-lang/rust/issues/21724