### PR TITLE
Revert "Move the combined components instead of copying"

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -79,13 +79,6 @@ pub fn remove_file<P: AsRef<Path>>(path: P) -> Result<()> {
         .chain_err(|| format!("failed to remove file '{}'", path.as_ref().display()))
 }
 
-/// Wrap `fs::rename` with a nicer error message
-pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<()> {
-    fs::rename(&from, &to)
-        .chain_err(|| format!("failed to rename '{}' to '{}'",
-                              from.as_ref().display(), to.as_ref().display()))
-}
-
 /// Copies the `src` directory recursively to `dst`. Both are assumed to exist
 /// when this function is called.
 pub fn copy_recursive(src: &Path, dst: &Path) -> Result<()> {

--- a/test.sh
+++ b/test.sh
@@ -946,6 +946,38 @@ list_components() {
 }
 runtest list_components
 
+combined_remains() {
+    try sh "$S/gen-installer.sh" \
+	--image-dir="$TEST_DIR/image1" \
+	--work-dir="$WORK_DIR" \
+	--output-dir="$OUT_DIR" \
+	--package-name=rustc \
+	--component-name=rustc
+    try sh "$S/gen-installer.sh" \
+	--image-dir="$TEST_DIR/image3" \
+	--work-dir="$WORK_DIR" \
+	--output-dir="$OUT_DIR" \
+	--package-name=cargo \
+	--component-name=cargo
+    try sh "$S/gen-installer.sh" \
+	--image-dir="$TEST_DIR/image4" \
+	--work-dir="$WORK_DIR" \
+	--output-dir="$OUT_DIR" \
+	--package-name=rust-docs \
+	--component-name=rust-docs
+    try sh "$S/combine-installers.sh" \
+	--work-dir="$WORK_DIR" \
+	--output-dir="$OUT_DIR" \
+	--package-name=rust \
+	--input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz,$OUT_DIR/rust-docs.tar.gz"
+    for component in rustc cargo rust-docs; do
+	# rustbuild wants the original extracted package intact too
+	try test -d "$WORK_DIR/$component/$component"
+	try test -d "$WORK_DIR/rust/$component"
+    done
+}
+runtest combined_remains
+
 # Upgrade tests
 
 upgrade_from_v1() {


### PR DESCRIPTION
This reverts commit 4f6e020b179ef79a3e3717f80132ad1a4875a669.

We need to leave the unpacked input packages intact for rustbuild to
reuse in OS-specific installers on macOS and Windows.  Add a test to
make sure the components are still present.