### PR TITLE
Use tar's append_data to add executables on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 [dependencies]
 error-chain = "0.10.0"
 flate2 = "0.2.19"
-tar = "0.4.11"
+tar = "0.4.13"
 walkdir = "1.0.7"
 xz2 = "0.1.3"
 


### PR DESCRIPTION
Since Windows doesn't really have Posix file modes, the tar crate only
sets file modes based on whether the source is readonly.  But we do want
stuff like `install.sh` to be executable when extracted elsewhere.

Now we create a manual header for our files, and add the executable bit
on files matching whitelisted extensions (exe, dll, py, sh).  That's not
trying to be exhaustive or perfect, but it's hopefully good enough to
have functional rust packages.