### PR TITLE
Don't force executable files in bulk dirs

### DIFF
--- a/install-template.sh
+++ b/install-template.sh
@@ -699,7 +699,7 @@ install_components() {
 		    critical_need_ok "failed to copy directory"
 
                     # Set permissions. 0755 for dirs, 644 for files
-                    run chmod -R u+rwx,go+rx,go-w "$_file_install_path"
+                    run chmod -R u+rwX,go+rX,go-w "$_file_install_path"
                     critical_need_ok "failed to set permissions on directory"
 
 		    # Update the manifest


### PR DESCRIPTION
With `chmod -R +x`, all files and directories will be marked executable.
With `chmod -R +X`, only those that already had *some* executable bit
will be updated.

It used to be this way before commit df54a5057419.  It seems that while
lower-casing some variable names, these flags were affected too.

Fixes #46.