### PR TITLE
Remove get_host_triple() from install-template.sh

### DIFF
--- a/install-template.sh
+++ b/install-template.sh
@@ -319,62 +319,6 @@ abs_path() {
     (unset CDPATH && cd "$path" > /dev/null && pwd)
 }
 
-get_host_triple() {
-    local _uname_value=$(uname -s)
-    local _ostype
-    case $_uname_value in
-
-	Linux)
-            _ostype=unknown-linux-gnu
-            ;;
-
-	FreeBSD)
-            _ostype=unknown-freebsd
-            ;;
-
-	DragonFly)
-            _ostype=unknown-dragonfly
-            ;;
-
-	Bitrig)
-            _ostype=unknown-bitrig
-            ;;
-
-	NetBSD)
-            _ostype=unknown-netbsd
-            ;;
-
-	OpenBSD)
-            _ostype=unknown-openbsd
-            ;;
-
-	Darwin)
-            _ostype=apple-darwin
-            ;;
-
-	MINGW*)
-            _ostype=pc-windows-gnu
-            ;;
-
-	MSYS*)
-            _ostype=pc-windows-gnu
-            ;;
-
-	CYGWIN*)
-            _ostype=pc-windows-gnu
-            ;;
-	Haiku)
-            _ostype=unknown-haiku
-            ;;
-
-	*)
-	    err "unknown value from uname -s: $_uname_value"
-	    ;;
-    esac
-
-    RETVAL="$_ostype"
-}
-
 uninstall_legacy() {
     local _abs_libdir="$1"
 
@@ -719,11 +663,10 @@ install_components() {
 maybe_configure_ld() {
     local _abs_libdir="$1"
 
-    get_host_triple
-    local _ostype="$RETVAL"
+    local _ostype="$(uname -s)"
     assert_nz "$_ostype"  "ostype"
 
-    if [ "$_ostype" = "unknown-linux-gnu" -a ! -n "${CFG_DISABLE_LDCONFIG-}" ]; then
+    if [ "$_ostype" = "Linux" -a ! -n "${CFG_DISABLE_LDCONFIG-}" ]; then
 
 	# Fedora-based systems do not configure the dynamic linker to look
 	# /usr/local/lib, which is our default installation directory. To
@@ -756,11 +699,10 @@ maybe_configure_ld() {
 }
 
 maybe_unconfigure_ld() {
-    get_host_triple
-    local _ostype="$RETVAL"
+    local _ostype="$(uname -s)"
     assert_nz "$_ostype"  "ostype"
 
-    if [ "$_ostype" != "unknown-linux-gnu" ]; then
+    if [ "$_ostype" != "Linux" ]; then
 	return 0
     fi
 


### PR DESCRIPTION
Rather than adding SunOS/Solaris (or any future supported OSes) to `get_host_triple()`'s list of known OSes, recognize that the function is called in exactly two places, and both times the only thing that matters is whether it's Linux or not.