### PR TITLE
Solaris fixes

### DIFF
--- a/combine-installers.sh
+++ b/combine-installers.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/gen-install-script.sh
+++ b/gen-install-script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/gen-installer.sh
+++ b/gen-installer.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/install-template.sh
+++ b/install-template.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.

--- a/install-template.sh
+++ b/install-template.sh
@@ -621,9 +621,11 @@ install_components() {
 
 		    if echo "$_file" | grep "^bin/" > /dev/null
 		    then
-			run install -m755 "$_src_dir/$_component/$_file" "$_file_install_path"
+			run cp "$_src_dir/$_component/$_file" "$_file_install_path"
+			run chmod 755 "$_file_install_path"
 		    else
-			run install -m644 "$_src_dir/$_component/$_file" "$_file_install_path"
+			run cp "$_src_dir/$_component/$_file" "$_file_install_path"
+			run chmod 644 "$_file_install_path"
 		    fi
 		    critical_need_ok "file creation failed"
 

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e -u
 


### PR DESCRIPTION
Currently, running the install scripts on Solaris requires putting `/usr/gnu/bin` first in `$PATH` to pick up GNU `install`, and explicit execution with `bash` since the `local` keyword isn't recognized by `/bin/sh` (`ksh93` in `sh`-mode). These changes use more compatible constructs.