### PR TITLE
preserve executable bit during installation

### DIFF
--- a/install-template.sh
+++ b/install-template.sh
@@ -619,7 +619,7 @@ install_components() {
 
 		    maybe_backup_path "$_file_install_path"
 
-		    if echo "$_file" | grep "^bin/" > /dev/null
+		    if echo "$_file" | grep "^bin/" > /dev/null || test -x "$_src_dir/$_component/$_file"
 		    then
 			run cp "$_src_dir/$_component/$_file" "$_file_install_path"
 			run chmod 755 "$_file_install_path"


### PR DESCRIPTION
This is essentially the rust-installer version of <https://github.com/rust-lang-nursery/rustup.rs/pull/1141>.

Fixes <https://github.com/rust-lang/rust/issues/44594>.