### PR TITLE
Stream the parallel xz/gz tarball generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ path = "src/main.rs"
 [dependencies]
 error-chain = "0.11.0"
 flate2 = "1.0.1"
+rayon = "0.9"
 tar = "0.4.13"
 walkdir = "1.0.7"
-xz2 = "0.1.3"
+xz2 = "0.1.4"
 
 [dependencies.clap]
 features = ["yaml"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 #[macro_use]
 extern crate error_chain;
 extern crate flate2;
+extern crate rayon;
 extern crate tar;
 extern crate walkdir;
 extern crate xz2;


### PR DESCRIPTION
This melds the serial-`Tee` and parallel-batched approaches from before
and after commit adea17e.  Now we can get the same multithreaded speedup
without having to build the entire uncompressed tarball in memory first.

The new `impl Write for RayonTee` uses `rayon::join` to split the
compression work for each buffer to separate threads.  This is scoped,
so it can be fully zero-copy, sharing the input buffer directly.  This
is all wrapped in a 1 MiB `BufWriter` to balance the cost of thread
wake-ups and synchronization.

The net performance is unchanged, using around 125% CPU -- approximately
4:1 time spent in xz versus gz.  The overall memory use is much reduced,
now independent of the tarball size -- just a few MiB on top of the
fixed-cost 674 MiB compressor memory requirements of `xz -9`.

Fixes #75.