### PR TITLE
Force shell scripts to keep their Unix line termination

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
On Unix systems, running a shell script with DOS line terminations
(CRLF) fails because the system attempts to execute whatever is on
the shebang, including the "\r" preceding the "\n".

For some reason, the rust-src tarball's install.sh started having CRLF
line endings starting June 29 on nightly (betas are affected as well).
This makes the install.sh file they contain non-executable.

The rust code that creates install.sh from install-template.sh doesn't
seem to do anything that would affect line terminations. So it seems
what might be happening is that those tarballs are now created on a
Windows machine, and the CRLFs slip in from autoconversion by git.

This .gitattributes should prevent such autoconversion.