### PR TITLE
Avoid non-standard escape sequences in tr command

### DIFF
--- a/install-template.sh
+++ b/install-template.sh
@@ -169,7 +169,7 @@ valopt() {
     local doc="$*"
     if [ $HELP -eq 0 ]
     then
-        local uop=$(echo $op | tr '[:lower:]' '[:upper:]' | tr '\-' '\_')
+        local uop=$(echo $op | tr '[:lower:]' '[:upper:]' | tr -- '-' '_')
         local v="CFG_${uop}"
         eval $v="$default"
         for arg in $CFG_ARGS

--- a/install-template.sh
+++ b/install-template.sh
@@ -169,7 +169,7 @@ valopt() {
     local doc="$*"
     if [ $HELP -eq 0 ]
     then
-        local uop=$(echo $op | tr '[:lower:]' '[:upper:]' | tr -- '-' '_')
+        local uop=$(echo $op | tr 'a-z-' 'A-Z_')
         local v="CFG_${uop}"
         eval $v="$default"
         for arg in $CFG_ARGS


### PR DESCRIPTION
POSIX says

> The <backslash>-escape sequences in Escape Sequences and Associated Actions ( '\\', '\a', '\b', '\f', '\n', '\r', '\t', '\v' ) shall be supported. The results of using any other character, other than an octal digit, following the <backslash> are unspecified. Also, if there is no character following the <backslash>, the results are unspecified.

Instead, just use `--` to separate options and operands, since tr(1)
is required to conform to the Utility Syntax Guidelines.