### PR TITLE
Migrate from failure to anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "fabricate"
 path = "src/main.rs"
 
 [dependencies]
-failure = "0.1"
+anyhow = "1.0.19"
 flate2 = "1.0.1"
 rayon = "1.0"
 tar = "0.4.13"

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,8 +1,7 @@
 use super::Scripter;
 use super::Tarballer;
 use crate::util::*;
-use crate::Result;
-use failure::{format_err, bail, ResultExt};
+use anyhow::{bail, format_err, Context, Result};
 use std::io::Write;
 use std::path::Path;
 
@@ -62,7 +61,7 @@ impl Generator {
         // Write the component name
         let components = package_dir.join("components");
         writeln!(create_new_file(components)?, "{}", self.component_name)
-            .with_context(|_| "failed to write the component file")?;
+            .context("failed to write the component file")?;
 
         // Write the installer version (only used by combine-installers.sh)
         let version = package_dir.join("rust-installer-version");
@@ -71,7 +70,7 @@ impl Generator {
             "{}",
             crate::RUST_INSTALLER_VERSION
         )
-        .with_context(|_| "failed to write new installer version")?;
+        .context("failed to write new installer version")?;
 
         // Copy the overlay
         if !self.non_installed_overlay.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-pub type Result<T> = std::result::Result<T, failure::Error>;
-
 #[macro_use]
 mod util;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
+use anyhow::{Context, Result};
 use clap::{App, ArgMatches};
-use failure::ResultExt;
-use installer::Result;
 
 fn main() -> Result<()> {
     let yaml = clap::load_yaml!("main.yml");
@@ -39,9 +38,7 @@ fn combine(matches: &ArgMatches<'_>) -> Result<()> {
         "output-dir" => output_dir,
     });
 
-    combiner
-        .run()
-        .with_context(|_| "failed to combine installers")?;
+    combiner.run().context("failed to combine installers")?;
     Ok(())
 }
 
@@ -60,9 +57,7 @@ fn generate(matches: &ArgMatches<'_>) -> Result<()> {
         "output-dir" => output_dir,
     });
 
-    generator
-        .run()
-        .with_context(|_| "failed to generate installer")?;
+    generator.run().context("failed to generate installer")?;
     Ok(())
 }
 
@@ -77,7 +72,7 @@ fn script(matches: &ArgMatches<'_>) -> Result<()> {
 
     scripter
         .run()
-        .with_context(|_| "failed to generate installation script")?;
+        .context("failed to generate installation script")?;
     Ok(())
 }
 
@@ -88,8 +83,6 @@ fn tarball(matches: &ArgMatches<'_>) -> Result<()> {
         "work-dir" => work_dir,
     });
 
-    tarballer
-        .run()
-        .with_context(|_| "failed to generate tarballs")?;
+    tarballer.run().context("failed to generate tarballs")?;
     Ok(())
 }

--- a/src/scripter.rs
+++ b/src/scripter.rs
@@ -1,7 +1,6 @@
-use std::io::Write;
-use failure::ResultExt;
-use crate::Result;
 use crate::util::*;
+use anyhow::{Context, Result};
+use std::io::Write;
 
 const TEMPLATE: &'static str = include_str!("../install-template.sh");
 
@@ -51,7 +50,7 @@ impl Scripter {
 
         create_new_executable(&self.output_script)?
             .write_all(script.as_ref())
-            .with_context(|_| format!("failed to write output script '{}'", self.output_script))?;
+            .with_context(|| format!("failed to write output script '{}'", self.output_script))?;
 
         Ok(())
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,4 @@
-use crate::Result;
-use failure::{format_err, ResultExt};
+use anyhow::{format_err, Context, Result};
 use std::fs;
 use std::path::Path;
 use walkdir::WalkDir;
@@ -27,7 +26,7 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<u64> {
         symlink_file(link, &to)?;
         Ok(0)
     } else {
-        let amt = fs::copy(&from, &to).with_context(|_| {
+        let amt = fs::copy(&from, &to).with_context(|| {
             format!(
                 "failed to copy '{}' to '{}'",
                 from.as_ref().display(),
@@ -41,14 +40,14 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<u64> {
 /// Wraps `fs::create_dir` with a nicer error message.
 pub fn create_dir<P: AsRef<Path>>(path: P) -> Result<()> {
     fs::create_dir(&path)
-        .with_context(|_| format!("failed to create dir '{}'", path.as_ref().display()))?;
+        .with_context(|| format!("failed to create dir '{}'", path.as_ref().display()))?;
     Ok(())
 }
 
 /// Wraps `fs::create_dir_all` with a nicer error message.
 pub fn create_dir_all<P: AsRef<Path>>(path: P) -> Result<()> {
     fs::create_dir_all(&path)
-        .with_context(|_| format!("failed to create dir '{}'", path.as_ref().display()))?;
+        .with_context(|| format!("failed to create dir '{}'", path.as_ref().display()))?;
     Ok(())
 }
 
@@ -60,7 +59,7 @@ pub fn create_new_executable<P: AsRef<Path>>(path: P) -> Result<fs::File> {
     options.mode(0o755);
     let file = options
         .open(&path)
-        .with_context(|_| format!("failed to create file '{}'", path.as_ref().display()))?;
+        .with_context(|| format!("failed to create file '{}'", path.as_ref().display()))?;
     Ok(file)
 }
 
@@ -70,28 +69,28 @@ pub fn create_new_file<P: AsRef<Path>>(path: P) -> Result<fs::File> {
         .write(true)
         .create_new(true)
         .open(&path)
-        .with_context(|_| format!("failed to create file '{}'", path.as_ref().display()))?;
+        .with_context(|| format!("failed to create file '{}'", path.as_ref().display()))?;
     Ok(file)
 }
 
 /// Wraps `fs::File::open()` with a nicer error message.
 pub fn open_file<P: AsRef<Path>>(path: P) -> Result<fs::File> {
     let file = fs::File::open(&path)
-        .with_context(|_| format!("failed to open file '{}'", path.as_ref().display()))?;
+        .with_context(|| format!("failed to open file '{}'", path.as_ref().display()))?;
     Ok(file)
 }
 
 /// Wraps `remove_dir_all` with a nicer error message.
 pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> Result<()> {
     remove_dir_all::remove_dir_all(path.as_ref())
-        .with_context(|_| format!("failed to remove dir '{}'", path.as_ref().display()))?;
+        .with_context(|| format!("failed to remove dir '{}'", path.as_ref().display()))?;
     Ok(())
 }
 
 /// Wrap `fs::remove_file` with a nicer error message
 pub fn remove_file<P: AsRef<Path>>(path: P) -> Result<()> {
     fs::remove_file(path.as_ref())
-        .with_context(|_| format!("failed to remove file '{}'", path.as_ref().display()))?;
+        .with_context(|| format!("failed to remove file '{}'", path.as_ref().display()))?;
     Ok(())
 }
 


### PR DESCRIPTION
The `failure` crate will likely be [deprecated](https://internals.rust-lang.org/t/failure-crate-maintenance/12087), and `anyhow` is nearly a drop-in replacement.