### PR TITLE
Convert posix scripts to bash

### DIFF
--- a/make-tarballs.sh
+++ b/make-tarballs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.


### PR DESCRIPTION
Addresses rust-lang/rust#31036

E: Force was because I saw the file had CRLF, not LF, so fixed.