### PR TITLE
Allow specifying the wanted compression formats at runtime

### DIFF
--- a/src/combiner.rs
+++ b/src/combiner.rs
@@ -1,6 +1,9 @@
 use super::Scripter;
 use super::Tarballer;
-use crate::{compression::CompressionFormat, util::*};
+use crate::{
+    compression::{CompressionFormat, CompressionFormats},
+    util::*,
+};
 use anyhow::{bail, Context, Result};
 use std::io::{Read, Write};
 use std::path::Path;
@@ -35,6 +38,9 @@ actor! {
 
         /// The location to put the final image and tarball.
         output_dir: String = "./dist",
+
+        /// The formats used to compress the tarball
+        compression_formats: CompressionFormats = CompressionFormats::default(),
     }
 }
 
@@ -136,7 +142,8 @@ impl Combiner {
         tarballer
             .work_dir(self.work_dir)
             .input(self.package_name)
-            .output(path_to_str(&output)?.into());
+            .output(path_to_str(&output)?.into())
+            .compression_formats(self.compression_formats.clone());
         tarballer.run()?;
 
         Ok(())

--- a/src/combiner.rs
+++ b/src/combiner.rs
@@ -121,7 +121,7 @@ impl Combiner {
             .rel_manifest_dir(self.rel_manifest_dir)
             .success_message(self.success_message)
             .legacy_manifest_dirs(self.legacy_manifest_dirs)
-            .output_script(path_to_str(&output_script)?);
+            .output_script(path_to_str(&output_script)?.into());
         scripter.run()?;
 
         // Make the tarballs.
@@ -131,7 +131,7 @@ impl Combiner {
         tarballer
             .work_dir(self.work_dir)
             .input(self.package_name)
-            .output(path_to_str(&output)?);
+            .output(path_to_str(&output)?.into());
         tarballer.run()?;
 
         Ok(())

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,0 +1,102 @@
+use anyhow::{Context, Error};
+use flate2::write::GzEncoder;
+use rayon::prelude::*;
+use std::{io::Write, path::Path};
+use xz2::write::XzEncoder;
+
+pub(crate) enum CompressionFormat {
+    Gz,
+    Xz,
+}
+
+impl CompressionFormat {
+    pub(crate) fn encode(&self, path: impl AsRef<Path>) -> Result<Box<dyn Encoder>, Error> {
+        let extension = match self {
+            CompressionFormat::Gz => ".gz",
+            CompressionFormat::Xz => ".xz",
+        };
+        let mut os = path.as_ref().as_os_str().to_os_string();
+        os.push(extension);
+        let path = Path::new(&os);
+
+        if path.exists() {
+            crate::util::remove_file(path)?;
+        }
+        let file = crate::util::create_new_file(path)?;
+
+        Ok(match self {
+            CompressionFormat::Gz => Box::new(GzEncoder::new(file, flate2::Compression::best())),
+            CompressionFormat::Xz => {
+                // Note that preset 6 takes about 173MB of memory per thread, so we limit the number of
+                // threads to not blow out 32-bit hosts.  (We could be more precise with
+                // `MtStreamBuilder::memusage()` if desired.)
+                let stream = xz2::stream::MtStreamBuilder::new()
+                    .threads(Ord::min(num_cpus::get(), 8) as u32)
+                    .preset(6)
+                    .encoder()?;
+                Box::new(XzEncoder::new_stream(file, stream))
+            }
+        })
+    }
+}
+
+pub(crate) trait Encoder: Send + Write {
+    fn finish(self: Box<Self>) -> Result<(), Error>;
+}
+
+impl<W: Send + Write> Encoder for GzEncoder<W> {
+    fn finish(self: Box<Self>) -> Result<(), Error> {
+        GzEncoder::finish(*self).context("failed to finish .gz file")?;
+        Ok(())
+    }
+}
+
+impl<W: Send + Write> Encoder for XzEncoder<W> {
+    fn finish(self: Box<Self>) -> Result<(), Error> {
+        XzEncoder::finish(*self).context("failed to finish .xz file")?;
+        Ok(())
+    }
+}
+
+pub(crate) struct CombinedEncoder {
+    encoders: Vec<Box<dyn Encoder>>,
+}
+
+impl CombinedEncoder {
+    pub(crate) fn new(encoders: Vec<Box<dyn Encoder>>) -> Box<dyn Encoder> {
+        Box::new(Self { encoders })
+    }
+}
+
+impl Write for CombinedEncoder {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.write_all(buf)?;
+        Ok(buf.len())
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        self.encoders
+            .par_iter_mut()
+            .map(|w| w.write_all(buf))
+            .collect::<std::io::Result<Vec<()>>>()?;
+        Ok(())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.encoders
+            .par_iter_mut()
+            .map(|w| w.flush())
+            .collect::<std::io::Result<Vec<()>>>()?;
+        Ok(())
+    }
+}
+
+impl Encoder for CombinedEncoder {
+    fn finish(self: Box<Self>) -> Result<(), Error> {
+        self.encoders
+            .into_par_iter()
+            .map(|e| e.finish())
+            .collect::<Result<Vec<()>, Error>>()?;
+        Ok(())
+    }
+}

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -85,7 +85,7 @@ impl Generator {
             .rel_manifest_dir(self.rel_manifest_dir)
             .success_message(self.success_message)
             .legacy_manifest_dirs(self.legacy_manifest_dirs)
-            .output_script(path_to_str(&output_script)?);
+            .output_script(path_to_str(&output_script)?.into());
         scripter.run()?;
 
         // Make the tarballs
@@ -95,7 +95,7 @@ impl Generator {
         tarballer
             .work_dir(self.work_dir)
             .input(self.package_name)
-            .output(path_to_str(&output)?);
+            .output(path_to_str(&output)?.into());
         tarballer.run()?;
 
         Ok(())

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,5 +1,6 @@
 use super::Scripter;
 use super::Tarballer;
+use crate::compression::CompressionFormats;
 use crate::util::*;
 use anyhow::{bail, format_err, Context, Result};
 use std::io::Write;
@@ -40,6 +41,9 @@ actor! {
 
         /// The location to put the final image and tarball
         output_dir: String = "./dist",
+
+        /// The formats used to compress the tarball
+        compression_formats: CompressionFormats = CompressionFormats::default(),
     }
 }
 
@@ -95,7 +99,8 @@ impl Generator {
         tarballer
             .work_dir(self.work_dir)
             .input(self.package_name)
-            .output(path_to_str(&output)?.into());
+            .output(path_to_str(&output)?.into())
+            .compression_formats(self.compression_formats.clone());
         tarballer.run()?;
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 mod util;
 
 mod combiner;
+mod compression;
 mod generator;
 mod scripter;
 mod tarballer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,7 @@ fn tarball(matches: &ArgMatches<'_>) -> Result<()> {
         "input" => input,
         "output" => output,
         "work-dir" => work_dir,
+        "compression-formats" => compression_formats,
     });
 
     tarballer.run().context("failed to generate tarballs")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,7 @@ fn generate(matches: &ArgMatches<'_>) -> Result<()> {
         "image-dir" => image_dir,
         "work-dir" => work_dir,
         "output-dir" => output_dir,
+        "compression-formats" => compression_formats,
     });
 
     generator.run().context("failed to generate installer")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use clap::{App, ArgMatches};
+use std::convert::TryInto;
 
 fn main() -> Result<()> {
     let yaml = clap::load_yaml!("main.yml");
@@ -19,7 +20,11 @@ macro_rules! parse(
     ($matches:expr => $type:ty { $( $option:tt => $setter:ident, )* }) => {
         {
             let mut command: $type = Default::default();
-            $( $matches.value_of($option).map(|s| command.$setter(s)); )*
+            $(
+                if let Some(val) = $matches.value_of($option) {
+                    command.$setter(val.try_into()?);
+                }
+            )*
             command
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ fn combine(matches: &ArgMatches<'_>) -> Result<()> {
         "non-installed-overlay" => non_installed_overlay,
         "work-dir" => work_dir,
         "output-dir" => output_dir,
+        "compression-formats" => compression_formats,
     });
 
     combiner.run().context("failed to combine installers")?;

--- a/src/main.yml
+++ b/src/main.yml
@@ -113,6 +113,11 @@ subcommands:
             long: output-dir
             takes_value: true
             value_name: DIR
+        - compression-formats:
+            help: Comma-separated list of compression formats to use
+            long: compression-formats
+            takes_value: true
+            value_name: FORMAT
   - script:
       about: Generate an installation script
       args:

--- a/src/main.yml
+++ b/src/main.yml
@@ -164,4 +164,9 @@ subcommands:
             long: work-dir
             takes_value: true
             value_name: DIR
+        - compression-formats:
+            help: Comma-separated list of compression formats to use
+            long: compression-formats
+            takes_value: true
+            value_name: FORMAT
 

--- a/src/main.yml
+++ b/src/main.yml
@@ -60,6 +60,11 @@ subcommands:
             long: output-dir
             takes_value: true
             value_name: DIR
+        - compression-formats:
+            help: Comma-separated list of compression formats to use
+            long: compression-formats
+            takes_value: true
+            value_name: FORMAT
   - combine:
       about: Combine installer tarballs
       args:

--- a/src/tarballer.rs
+++ b/src/tarballer.rs
@@ -1,13 +1,11 @@
 use anyhow::{bail, Context, Result};
-use flate2::write::GzEncoder;
 use std::fs::{read_link, symlink_metadata};
-use std::io::{self, empty, BufWriter, Write};
+use std::io::{empty, BufWriter, Write};
 use std::path::Path;
 use tar::{Builder, Header};
 use walkdir::WalkDir;
-use xz2::write::XzEncoder;
 
-use crate::util::*;
+use crate::{compression::CombinedEncoder, compression::CompressionFormat, util::*};
 
 actor! {
     #[derive(Debug)]
@@ -26,15 +24,11 @@ actor! {
 impl Tarballer {
     /// Generates the actual tarballs
     pub fn run(self) -> Result<()> {
-        let tar_gz = self.output.clone() + ".tar.gz";
-        let tar_xz = self.output.clone() + ".tar.xz";
-
-        // Remove any existing files.
-        for file in &[&tar_gz, &tar_xz] {
-            if Path::new(file).exists() {
-                remove_file(file)?;
-            }
-        }
+        let tarball_name = self.output.clone() + ".tar";
+        let encoder = CombinedEncoder::new(vec![
+            CompressionFormat::Gz.encode(&tarball_name)?,
+            CompressionFormat::Xz.encode(&tarball_name)?,
+        ]);
 
         // Sort files by their suffix, to group files with the same name from
         // different locations (likely identical) and files with the same
@@ -43,22 +37,9 @@ impl Tarballer {
             .context("failed to collect file paths")?;
         files.sort_by(|a, b| a.bytes().rev().cmp(b.bytes().rev()));
 
-        // Prepare the `.tar.gz` file.
-        let gz = GzEncoder::new(create_new_file(tar_gz)?, flate2::Compression::best());
-
-        // Prepare the `.tar.xz` file. Note that preset 6 takes about 173MB of memory
-        // per thread, so we limit the number of threads to not blow out 32-bit hosts.
-        // (We could be more precise with `MtStreamBuilder::memusage()` if desired.)
-        let stream = xz2::stream::MtStreamBuilder::new()
-            .threads(Ord::min(num_cpus::get(), 8) as u32)
-            .preset(6)
-            .encoder()?;
-        let xz = XzEncoder::new_stream(create_new_file(tar_xz)?, stream);
-
         // Write the tar into both encoded files. We write all directories
         // first, so files may be directly created. (See rust-lang/rustup.rs#1092.)
-        let tee = RayonTee(xz, gz);
-        let buf = BufWriter::with_capacity(1024 * 1024, tee);
+        let buf = BufWriter::with_capacity(1024 * 1024, encoder);
         let mut builder = Builder::new(buf);
 
         let pool = rayon::ThreadPoolBuilder::new()
@@ -77,20 +58,14 @@ impl Tarballer {
                 append_path(&mut builder, &src, &path)
                     .with_context(|| format!("failed to tar file '{}'", src.display()))?;
             }
-            let RayonTee(xz, gz) = builder
+            builder
                 .into_inner()
                 .context("failed to finish writing .tar stream")?
                 .into_inner()
                 .ok()
-                .unwrap();
+                .unwrap()
+                .finish()?;
 
-            // Finish both encoded files.
-            let (rxz, rgz) = rayon::join(
-                || xz.finish().context("failed to finish .tar.xz file"),
-                || gz.finish().context("failed to finish .tar.gz file"),
-            );
-            rxz?;
-            rgz?;
             Ok(())
         })
     }
@@ -153,25 +128,4 @@ where
         }
     }
     Ok((dirs, files))
-}
-
-struct RayonTee<A, B>(A, B);
-
-impl<A: Write + Send, B: Write + Send> Write for RayonTee<A, B> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.write_all(buf)?;
-        Ok(buf.len())
-    }
-
-    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        let (a, b) = (&mut self.0, &mut self.1);
-        let (ra, rb) = rayon::join(|| a.write_all(buf), || b.write_all(buf));
-        ra.and(rb)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        let (a, b) = (&mut self.0, &mut self.1);
-        let (ra, rb) = rayon::join(|| a.flush(), || b.flush());
-        ra.and(rb)
-    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -142,8 +142,8 @@ macro_rules! actor {
 
         impl $name {
             $( $( #[ $field_attr ] )+
-            pub fn $field<T: Into<$type>>(&mut self, value: T) -> &mut Self {
-                self.$field = value.into();
+            pub fn $field(&mut self, value: $type) -> &mut Self {
+                self.$field = value;
                 self
             })+
         }

--- a/test.sh
+++ b/test.sh
@@ -1229,6 +1229,78 @@ generate_compression_formats_error() {
 }
 runtest generate_compression_formats_error
 
+combine_compression_formats_one() {
+    try sh "$S/gen-installer.sh" \
+        --image-dir="$TEST_DIR/image1" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name=rustc \
+        --component-name=rustc
+    try sh "$S/gen-installer.sh" \
+        --image-dir="$TEST_DIR/image3" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name=cargo \
+        --component-name=cargo
+    try sh "$S/combine-installers.sh" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name=rust \
+        --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz" \
+        --compression-formats=xz
+
+    try test ! -e "${OUT_DIR}/rust.tar.gz"
+    try test -e "${OUT_DIR}/rust.tar.xz"
+}
+runtest combine_compression_formats_one
+
+combine_compression_formats_multiple() {
+    try sh "$S/gen-installer.sh" \
+        --image-dir="$TEST_DIR/image1" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name=rustc \
+        --component-name=rustc
+    try sh "$S/gen-installer.sh" \
+        --image-dir="$TEST_DIR/image3" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name=cargo \
+        --component-name=cargo
+    try sh "$S/combine-installers.sh" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name=rust \
+        --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz" \
+        --compression-formats=xz,gz
+
+    try test -e "${OUT_DIR}/rust.tar.gz"
+    try test -e "${OUT_DIR}/rust.tar.xz"
+}
+runtest combine_compression_formats_multiple
+
+combine_compression_formats_error() {
+    try sh "$S/gen-installer.sh" \
+        --image-dir="$TEST_DIR/image1" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name=rustc \
+        --component-name=rustc
+    try sh "$S/gen-installer.sh" \
+        --image-dir="$TEST_DIR/image3" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name=cargo \
+        --component-name=cargo
+    expect_fail sh "$S/combine-installers.sh" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name=rust \
+        --input-tarballs="$OUT_DIR/rustc.tar.gz,$OUT_DIR/cargo.tar.gz" \
+        --compression-formats=xz,foobar
+}
+runtest combine_compression_formats_error
+
 echo
 echo "TOTAL SUCCESS!"
 echo

--- a/test.sh
+++ b/test.sh
@@ -1190,6 +1190,45 @@ combine_installers_different_input_compression_formats() {
 }
 runtest combine_installers_different_input_compression_formats
 
+generate_compression_formats_one() {
+    try sh "$S/gen-installer.sh" \
+        --image-dir="$TEST_DIR/image1" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name="rustc" \
+        --component-name="rustc" \
+        --compression-formats="xz"
+
+    try test ! -e "${OUT_DIR}/rustc.tar.gz"
+    try test -e "${OUT_DIR}/rustc.tar.xz"
+}
+runtest generate_compression_formats_one
+
+generate_compression_formats_multiple() {
+    try sh "$S/gen-installer.sh" \
+        --image-dir="$TEST_DIR/image1" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name="rustc" \
+        --component-name="rustc" \
+        --compression-formats="gz,xz"
+
+    try test -e "${OUT_DIR}/rustc.tar.gz"
+    try test -e "${OUT_DIR}/rustc.tar.xz"
+}
+runtest generate_compression_formats_multiple
+
+generate_compression_formats_error() {
+    expect_fail sh "$S/gen-installer.sh" \
+        --image-dir="$TEST_DIR/image1" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name="rustc" \
+        --component-name="rustc" \
+        --compression-formats="xz,foobar"
+}
+runtest generate_compression_formats_error
+
 echo
 echo "TOTAL SUCCESS!"
 echo

--- a/test.sh
+++ b/test.sh
@@ -1164,6 +1164,32 @@ docdir_combined() {
 }
 runtest docdir_combined
 
+combine_installers_different_input_compression_formats() {
+    try sh "$S/gen-installer.sh" \
+        --image-dir="$TEST_DIR/image1" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name=rustc \
+        --component-name=rustc \
+        --compression-formats=xz
+    try sh "$S/gen-installer.sh" \
+        --image-dir="$TEST_DIR/image3" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name=cargo \
+        --component-name=cargo \
+        --compression-formats=gz
+    try sh "$S/combine-installers.sh" \
+        --work-dir="$WORK_DIR" \
+        --output-dir="$OUT_DIR" \
+        --package-name=rust \
+        --input-tarballs="$OUT_DIR/rustc.tar.xz,$OUT_DIR/cargo.tar.gz"
+
+    try test -e "${OUT_DIR}/rust.tar.gz"
+    try test -e "${OUT_DIR}/rust.tar.xz"
+}
+runtest combine_installers_different_input_compression_formats
+
 echo
 echo "TOTAL SUCCESS!"
 echo

--- a/test.sh
+++ b/test.sh
@@ -1301,6 +1301,42 @@ combine_compression_formats_error() {
 }
 runtest combine_compression_formats_error
 
+tarball_compression_formats_one() {
+    try cp -r "${TEST_DIR}/image1" "${WORK_DIR}/image"
+    try sh "$S/make-tarballs.sh" \
+        --input="${WORK_DIR}/image" \
+        --work-dir="${WORK_DIR}" \
+        --output="${OUT_DIR}/rustc" \
+        --compression-formats="xz"
+
+    try test ! -e "${OUT_DIR}/rustc.tar.gz"
+    try test -e "${OUT_DIR}/rustc.tar.xz"
+}
+runtest tarball_compression_formats_one
+
+tarball_compression_formats_multiple() {
+    try cp -r "${TEST_DIR}/image1" "${WORK_DIR}/image"
+    try sh "$S/make-tarballs.sh" \
+        --input="${WORK_DIR}/image" \
+        --work-dir="${WORK_DIR}" \
+        --output="${OUT_DIR}/rustc" \
+        --compression-formats="xz,gz"
+
+    try test -e "${OUT_DIR}/rustc.tar.gz"
+    try test -e "${OUT_DIR}/rustc.tar.xz"
+}
+runtest tarball_compression_formats_multiple
+
+tarball_compression_formats_error() {
+    try cp -r "${TEST_DIR}/image1" "${WORK_DIR}/image"
+    expect_fail sh "$S/make-tarballs.sh" \
+        --input="${WORK_DIR}/image" \
+        --work-dir="${WORK_DIR}" \
+        --output="${OUT_DIR}/rustc" \
+        --compression-formats="xz,foobar"
+}
+runtest tarball_compression_formats_error
+
 echo
 echo "TOTAL SUCCESS!"
 echo


### PR DESCRIPTION
This PR adds the `--compression-formats` option to the `generate`, `combine` and `tarball` subcommands, allowing to choose one or more output formats to generate. If the flag is not present the default set of formats is generated (`gz` and `xz`):

```
cargo run -- generate --compression-formats=xz ...
cargo run -- generate --compression-formats=gz,xz ...
```

The `combine` subcommand is also tweaked to allow combining tarballs compressed using any of the supported formats, instead of only allowing gzip-compressed tarballs.

All of this will allow rustc's CI to choose which formats to generate, and it will allow to easily add new formats in the future.

This PR can be reviewed commit-by-commit.
r? @alexcrichton 