### PR TITLE
install.sh: Perfomance: Use more shell builtins

### DIFF
--- a/install-template.sh
+++ b/install-template.sh
@@ -174,11 +174,11 @@ valopt() {
         eval $v="$default"
         for arg in $CFG_ARGS
         do
-            if echo "$arg" | grep -q -- "--$op="
-            then
-                local val=$(echo "$arg" | cut -f2 -d=)
-                eval $v=$val
-            fi
+            case "${arg}" in
+                "--${op}="* )
+                    local val="${arg#--${op}=}"
+                    eval $v=$val
+            esac
         done
         putvar $v
     else
@@ -280,10 +280,10 @@ validate_opt () {
         done
         for option in $VAL_OPTIONS
         do
-            if echo "$arg" | grep -q -- "--$option="
-            then
-                is_arg_valid=1
-            fi
+            case "${arg}" in
+                "--${option}="* )
+                    is_arg_valid=1
+            esac
         done
         if [ "$arg" = "--help" ]
         then
@@ -302,8 +302,8 @@ validate_opt () {
 
 absolutify() {
     local file_path="$1"
-    local file_path_dirname="$(dirname "$file_path")"
-    local file_path_basename="$(basename "$file_path")"
+    local file_path_dirname="${file_path%/*}"
+    local file_path_basename="${file_path##*/}"
     local file_abs_path="$(abs_path "$file_path_dirname")"
     local file_path="$file_abs_path/$file_path_basename"
     # This is the return value
@@ -442,8 +442,8 @@ uninstall_components() {
 		    local _directive
 		    while read _directive; do
 
-			local _command=`echo $_directive | cut -f1 -d:`
-			local _file=`echo $_directive | cut -f2 -d:`
+			local _command="${_directive%%:*}"
+			local _file="${_directive#*:}"
 
 			# Sanity checks
 			if [ ! -n "$_command" ]; then critical_err "malformed installation directive"; fi
@@ -549,8 +549,8 @@ install_components() {
 	local _directive
 	while read _directive; do
 
-	    local _command=`echo $_directive | cut -f1 -d:`
-	    local _file=`echo $_directive | cut -f2 -d:`
+	    local _command="${_directive%%:*}"
+	    local _file="${_directive#*:}"
 
 	    # Sanity checks
 	    if [ ! -n "$_command" ]; then critical_err "malformed installation directive"; fi
@@ -559,35 +559,23 @@ install_components() {
 	    # Decide the destination of the file
 	    local _file_install_path="$_dest_prefix/$_file"
 
-	    if echo "$_file" | grep "^etc/" > /dev/null
-	    then
-		local _f="$(echo "$_file" | sed 's/^etc\///')"
-		_file_install_path="$CFG_SYSCONFDIR/$_f"
-	    fi
-
-	    if echo "$_file" | grep "^bin/" > /dev/null
-	    then
-		local _f="$(echo "$_file" | sed 's/^bin\///')"
-		_file_install_path="$CFG_BINDIR/$_f"
-	    fi
-
-	    if echo "$_file" | grep "^lib/" > /dev/null
-	    then
-		local _f="$(echo "$_file" | sed 's/^lib\///')"
-		_file_install_path="$CFG_LIBDIR/$_f"
-	    fi
-
-	    if echo "$_file" | grep "^share" > /dev/null
-	    then
-		local _f="$(echo "$_file" | sed 's/^share\///')"
-		_file_install_path="$CFG_DATADIR/$_f"
-	    fi
-
-	    if echo "$_file" | grep "^share/man/" > /dev/null
-	    then
-		local _f="$(echo "$_file" | sed 's/^share\/man\///')"
-		_file_install_path="$CFG_MANDIR/$_f"
-	    fi
+        case "${_file}" in
+            etc/* )
+                _file_install_path="$CFG_SYSCONFDIR/${_file#etc/}"
+            ;;
+            bin/* )
+                _file_install_path="$CFG_BINDIR/${_file#bin/}"
+            ;;
+            lib/* )
+                _file_install_path="$CFG_LIBDIR/${_file#lib/}"
+            ;;
+            share/man/* )
+                _file_install_path="$CFG_MANDIR/${_file#share/man/}"
+            ;;
+            share/* )
+                _file_install_path="$CFG_DATADIR/${_file#share/}"
+            ;;
+        esac
 
             # HACK: Try to support overriding --docdir.  Paths with the form
             # "share/doc/$product/" can be redirected to a single --docdir
@@ -601,15 +589,14 @@ install_components() {
             # this problem to be a big deal in practice.
             if [ "$CFG_DOCDIR" != "<default>" ]
             then
-	        if echo "$_file" | grep "^share/doc/" > /dev/null
-	        then
-		    local _f="$(echo "$_file" | sed 's/^share\/doc\/[^/]*\///')"
-		    _file_install_path="$CFG_DOCDIR/$_f"
-	        fi
+                case "${_file}" in
+                    share/doc/* )
+                    _file_install_path="$CFG_DOCDIR/${_file#share/doc/*/}"
+                esac
             fi
 
 	    # Make sure there's a directory for it
-	    make_dir_recursive "$(dirname "$_file_install_path")"
+	    make_dir_recursive "${_file_install_path%/*}"
 	    critical_need_ok "directory creation failed"
 
 	    # Make the path absolute so we can uninstall it later without
@@ -625,7 +612,7 @@ install_components() {
 
 		    maybe_backup_path "$_file_install_path"
 
-		    if echo "$_file" | grep "^bin/" > /dev/null || test -x "$_src_dir/$_component/$_file"
+		    if test -z "${_file##bin/*}" || test -x "$_src_dir/$_component/$_file"
 		    then
 			run cp "$_src_dir/$_component/$_file" "$_file_install_path"
 			run chmod 755 "$_file_install_path"
@@ -770,8 +757,6 @@ verbose_msg
 
 need_cmd mkdir
 need_cmd printf
-need_cmd cut
-need_cmd grep
 need_cmd uname
 need_cmd tr
 need_cmd sed


### PR DESCRIPTION
Replace echo/grep/cut/dirname/basename by variable substitutions and
case pattern matching to reduce the amount of subprocesses called for
every copied file.

The current `echo | grep`/`echo | cut`/`dirname`/`basename` invocations slow down the installation process, esp. when components with many files (`rust-docs`) are processed.
This pull request replaces them with shell builtin substitutions to avoid process calling overhead.
Locally for me, these small changes reduced the install time (for `rust-docs` only) from around 20 minutes to around 3 minutes.