### PR TITLE
Add manifest on Windows to avoid UAC popups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ version = "3.1"
 [target."cfg(windows)".dependencies]
 lazy_static = "1"
 winapi = { version = "0.3", features = ["errhandlingapi", "handleapi", "ioapiset", "winerror", "winioctl", "winnt"] }
+
+[build-dependencies]
+embed-manifest = "1.3.1"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+use embed_manifest::{embed_manifest, new_manifest};
+
+fn main() {
+    if std::env::var_os("CARGO_CFG_WINDOWS").is_some() {
+        embed_manifest(new_manifest("Rust.Installer")).expect("unable to embed manifest file");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}


### PR DESCRIPTION
Since rename (https://github.com/rust-lang/rust-installer/pull/113) rust installer triggers Windows ~~bug~~ feature that makes 32-bit binaries with specific strings automatically trigger UAC prompt (https://learn.microsoft.com/en-us/previous-versions/aa905330(v=msdn.10)#installer-detection).
This is an issue when running program in non-elevated shell like we do at MSYS2: https://github.com/msys2/MINGW-packages/issues/9091#issuecomment-1294257143, For that reason we carry this PR as downstream patch.

Here is how manifest is configured by the default with `embed-manifest` crate: https://docs.rs/embed-manifest/1.3.1/embed_manifest/fn.new_manifest.html