### PR TITLE
Fix --without-components with subsetted components

### DIFF
--- a/install-template.sh
+++ b/install-template.sh
@@ -921,9 +921,27 @@ fi
 
 if [ -n "$CFG_WITHOUT" ]; then
     without_components="$(echo "$CFG_WITHOUT" | sed "s/,/ /g")"
-    for without_component in $without_components; do
-	components="$(echo "$components" | sed "s/$without_component//" | sed "s/$without_component//")"
+
+    # This does **not** check that all components in without_components are
+    # actually present in the list of available components.
+    #
+    # Currently that's considered good as it makes it easier to be compatible
+    # with multiple Rust versions (which may change the exact list of
+    # components) when writing install scripts.
+    new_comp=""
+    for component in $components; do
+        found=false
+        for my_component in $without_components; do
+            if [ "$component" = "$my_component" ]; then
+                found=true
+            fi
+        done
+        if [ "$found" = false ]; then
+            # If we didn't find the component in without, then add it to new list.
+            new_comp="$new_comp $component"
+        fi
     done
+    components="$new_comp"
 fi
 
 if [ -z "$components" ]; then


### PR DESCRIPTION
It's not entirely clear what changed in 1.66, but rust-lang/rust#105755 shows that we are failing to run the install script with --without if there are subsetted component names.

This changes the behavior of the filtering to require an *exact* match rather than a partial match, which seems like the better way to go. It's not very clear to me that the previous behavior was actually a good idea. 

r? @jyn514 or @pietroalbini 
cc https://github.com/rust-lang/rust/issues/105755

Will run a try build + dev-static nightly to check this actually works, but altering the 1.66 release with these changes did seem to do the right thing. (But I think the easiest thing is to merge this first and then do that later).