### PR TITLE
template: Update tr(1) usage for Solaris compat

### DIFF
--- a/install-template.sh
+++ b/install-template.sh
@@ -169,7 +169,7 @@ valopt() {
     local doc="$*"
     if [ $HELP -eq 0 ]
     then
-        local uop=$(echo $op | tr 'a-z-' 'A-Z_')
+        local uop=$(echo $op | tr '[a-z]-' '[A-Z]_')
         local v="CFG_${uop}"
         eval $v="$default"
         for arg in $CFG_ARGS
@@ -215,8 +215,8 @@ opt() {
         do
             if [ "$arg" = "--${flag}-${op}" ]
             then
-                op=$(echo $op | tr 'a-z-' 'A-Z_')
-                flag=$(echo $flag | tr 'a-z' 'A-Z')
+                op=$(echo $op | tr '[a-z]-' '[A-Z]_')
+                flag=$(echo $flag | tr '[a-z]' '[A-Z]')
                 local v="CFG_${flag}_${op}"
                 eval $v=1
                 putvar $v
@@ -244,7 +244,7 @@ flag() {
         do
             if [ "$arg" = "--${op}" ]
             then
-                op=$(echo $op | tr 'a-z-' 'A-Z_')
+                op=$(echo $op | tr '[a-z]-' '[A-Z]_')
                 local v="CFG_${op}"
                 eval $v=1
                 putvar $v


### PR DESCRIPTION
Seems like wrapping the character range with square brackets is safe for both BSD and GNU `tr(1)`.  Without the brackets Solaris' `tr(1)` chokes and treats `-` as a literal and not a range despite the man page suggesting otherwise.  The SUSv2 (`/usr/xpg4/bin/tr`) and SUSv3 (`/usr/xpg6/bin/tr`) versions likewise don't function as intended without the brackets. 

With these changes in place the installer works on Solaris 11.4.

On Solaris:
```
$ pkg list entire
NAME (PUBLISHER)                                  VERSION                    IFO
entire                                            11.4-11.4.0.0.1.15.0       i--

$ echo 'foobar-1' | /usr/bin/tr 'a-z-' 'A-Z_'
foobAr_1

$ echo 'foobar-1' | /usr/bin/tr '[a-z]-' '[A-Z]_'
FOOBAR_1
```

On macOS 10.14:
```
$ echo 'foobar-1' | /usr/bin/tr 'a-z-' 'A-Z_'
FOOBAR_1

$ echo 'foobar-1' | /usr/bin/tr '[a-z]-' '[A-Z]_'
FOOBAR_1

$ gtr --version
tr (GNU coreutils) 9.3
Copyright (C) 2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>. This is free software: you are free to change and redistribute it. There is NO WARRANTY, to the extent permitted by law.

Written by Jim Meyering.

$ echo 'foobar-1' | /opt/local/bin/gtr 'a-z-' 'A-Z_'
FOOBAR_1

$ echo 'foobar-1' | /opt/local/bin/gtr '[a-z]-' '[A-Z]_'
FOOBAR_1
```